### PR TITLE
compatible: redmine 2.4.X

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,3 +3,13 @@
 Replaces cweek with day on Redmine's gannt chart.
 
 https://raw.github.com/vividtone/redmine_gantt_with_date/master/screenshot.png
+
+= Compatible
+
+Only => 2.4.X
+
+= Caution
+
+This plugin is overwritten the view(show.html) for gantt.
+
+So can't use any plugin use the view(show.html) for gantt at the same time.

--- a/app/views/gantts/show.html.erb
+++ b/app/views/gantts/show.html.erb
@@ -1,4 +1,11 @@
 <% @gantt.view = self %>
+<div class="contextual">
+<% if !@query.new_record? && @query.editable_by?(User.current) %>
+  <%= link_to l(:button_edit), edit_query_path(@query, :gantt => 1), :class => 'icon icon-edit' %>
+  <%= delete_link query_path(@query, :gantt => 1) %>
+<% end %>
+</div>
+
 <h2><%= @query.new_record? ? l(:label_gantt) : h(@query.name) %></h2>
 
 <%= form_tag({:controller => 'gantts', :action => 'show',
@@ -6,6 +13,7 @@
              :year => params[:year], :months => params[:months]},
              :method => :get, :id => 'query_form') do %>
 <%= hidden_field_tag 'set_filter', '1' %>
+<%= hidden_field_tag 'gantt', '1' %>
 <fieldset id="filters" class="collapsible <%= @query.new_record? ? "" : "collapsed" %>">
   <legend onclick="toggleFieldset(this);"><%= l(:label_filter_plural) %></legend>
   <div style="<%= @query.new_record? ? "" : "display: none;" %>">
@@ -20,8 +28,8 @@
         <td>
           <fieldset>
             <legend><%= l(:label_related_issues) %></legend>
-            <label>
-              <%= check_box_tag "draw_rels", params["draw_rels"], params[:set_filter].blank? || params[:draw_rels] %>
+            <label for="draw_relations">
+              <%= check_box 'query', 'draw_relations', :id => 'draw_relations' %>
               <% rels = [IssueRelation::TYPE_BLOCKS, IssueRelation::TYPE_PRECEDES] %>
               <% rels.each do |rel| %>
                 <% color = Redmine::Helpers::Gantt::DRAW_TYPES[rel][:color] %>
@@ -35,8 +43,8 @@
         <td>
           <fieldset>
             <legend><%= l(:label_gantt_progress_line) %></legend>
-            <label>
-              <%= check_box_tag "draw_progress_line", params[:draw_progress_line], params[:draw_progress_line] %>
+            <label for="draw_progress_line">
+              <%= check_box 'query', 'draw_progress_line', :id => 'draw_progress_line' %>
               <%= l(:label_display) %>
             </label>
           </fieldset>
@@ -62,6 +70,11 @@
                      :class => 'icon icon-checked' %>
 <%= link_to l(:button_clear), { :project_id => @project, :set_filter => 1 },
             :class => 'icon icon-reload' %>
+<% if @query.new_record? && User.current.allowed_to?(:save_queries, @project, :global => true) %>
+  <%= link_to_function l(:button_save),
+                       "$('#query_form').attr('action', '#{ @project ? new_project_query_path(@project) : new_query_path }').submit();",
+                       :class => 'icon icon-save' %>
+<% end %>
 </p>
 <% end %>
 
@@ -194,55 +207,57 @@
       <% end %>
       <% left = left + width + 1 %>
     <% end %>
-    <%# gantt_with_date end %>
+  <% else %>
+  <%# gantt_with_date end %>
+
+  <%
+    left = 0
+    height = (show_days ? header_height - 1 : header_height - 1 + g_height)
+  %>
+  <% if @gantt.date_from.cwday == 1 %>
+    <%
+      # @date_from is monday
+      week_f = @gantt.date_from
+    %>
   <% else %>
     <%
-      left = 0
-      height = (show_days ? header_height - 1 : header_height - 1 + g_height)
+      # find next monday after @date_from
+      week_f = @gantt.date_from + (7 - @gantt.date_from.cwday + 1)
+      width = (7 - @gantt.date_from.cwday + 1) * zoom - 1
+      style  = ""
+      style += "left: #{left}px;"
+      style += "top: 19px;"
+      style += "width: #{width}px;"
+      style += "height: #{height}px;"
     %>
-    <% if @gantt.date_from.cwday == 1 %>
-      <%
-        # @date_from is monday
-        week_f = @gantt.date_from
-      %>
-    <% else %>
-      <%
-        # find next monday after @date_from
-        week_f = @gantt.date_from + (7 - @gantt.date_from.cwday + 1)
-        width = (7 - @gantt.date_from.cwday + 1) * zoom - 1
-        style  = ""
-        style += "left: #{left}px;"
-        style += "top: 19px;"
-        style += "width: #{width}px;"
-        style += "height: #{height}px;"
-      %>
-      <%= content_tag(:div, '&nbsp;'.html_safe,
-                      :style => style, :class => "gantt_hdr") %>
-      <% left = left + width + 1 %>
-    <% end %>
-    <% while week_f <= @gantt.date_to %>
-      <%
-        width = ((week_f + 6 <= @gantt.date_to) ?
-                    7 * zoom - 1 :
-                    (@gantt.date_to - week_f + 1) * zoom - 1).to_i
-        style  = ""
-        style += "left: #{left}px;"
-        style += "top: 19px;"
-        style += "width: #{width}px;"
-        style += "height: #{height}px;"
-      %>
-      <%= content_tag(:div, :style => style, :class => "gantt_hdr") do %>
-        <%= content_tag(:small) do %>
-          <%= week_f.day %> <%# gantt_with_date %>
-        <% end %>
+    <%= content_tag(:div, '&nbsp;'.html_safe,
+                    :style => style, :class => "gantt_hdr") %>
+    <% left = left + width + 1 %>
+  <% end %>
+  <% while week_f <= @gantt.date_to %>
+    <%
+      width = ((week_f + 6 <= @gantt.date_to) ?
+                  7 * zoom - 1 :
+                  (@gantt.date_to - week_f + 1) * zoom - 1).to_i
+      style  = ""
+      style += "left: #{left}px;"
+      style += "top: 19px;"
+      style += "width: #{width}px;"
+      style += "height: #{height}px;"
+    %>
+    <%= content_tag(:div, :style => style, :class => "gantt_hdr") do %>
+      <%= content_tag(:small) do %>
+        <%= week_f.cweek if width >= 16 %>
       <% end %>
-      <%
-        left = left + width + 1
-        week_f = week_f + 7
-      %>
     <% end %>
+    <%
+      left = left + width + 1
+      week_f = week_f + 7
+    %>
   <% end %>
 <% end %>
+<% end %>
+
 
 <% ###### Days headers ####### %>
 <% if show_days %>
@@ -306,11 +321,11 @@
 
 <table style="width:100%">
 <tr>
-  <td align="left">
+  <td style="text-align:left;">
     <%= link_to_content_update("\xc2\xab " + l(:label_previous),
                                params.merge(@gantt.params_previous)) %>
   </td>
-  <td align="right">
+  <td style="text-align:right;">
     <%= link_to_content_update(l(:label_next) + " \xc2\xbb",
                                params.merge(@gantt.params_next)) %>
   </td>
@@ -339,7 +354,7 @@
   $(document).ready(drawGanttHandler);
   $(window).resize(drawGanttHandler);
   $(function() {
-    $("#draw_rels").change(drawGanttHandler);
+    $("#draw_relations").change(drawGanttHandler);
     $("#draw_progress_line").change(drawGanttHandler);
   });
 <% end %>

--- a/init.rb
+++ b/init.rb
@@ -7,4 +7,7 @@ Redmine::Plugin.register :redmine_gantt_with_date do
   version '0.0.1'
   url 'https://github.com/vividtone/redmine_gantt_with_date'
   author_url 'https://www.facebook.com/MAEDA.Go'
+
+  # add require version
+  requires_redmine :version_or_higher => '2.4.0'
 end


### PR DESCRIPTION
日本の方とお見受けし、日本語にて失礼します。
redmine_gantt_with_dateを利用させて頂いている一人です。
シンプルながら日本にはなくてはならない表示で、
愛用させて頂いております。
ありがとうございます。

この度、redmine2.4.Xから導入された依存線に
redmine_gantt_with_dateが対応されていなかったため、
対応版を作成致しました。

内容としましては、新しいshow.htmlを持ってきて、
そこに貴方にて作成された該当ロジックをコピペしただけです。
そのままではredmine2.3以下にて動作しなくなる恐れがあるため、
念のため、init.rbにてredmineのバージョンを指定しました。

もしよろしければ、ご確認頂ければと思います。
性質上、masterへのマージは難しいと思いますので、
branchとして採用して頂ければ幸いです。
## 

Hello! Nice to meet you.

Thank you for creating "redmine_gantt_with_date".
It's very useful! I like it!
Now, I make it for redmine 2.4.X.

please check it.
